### PR TITLE
Use errors for context state

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Both the extension and command groups allow for type based persistent state valu
 Extension state is accessible from any command handler.
 
 ```rust,skt-call-init
-use arma_rs::{arma, Context, Extension};
+use arma_rs::{arma, Context, ContextState, ContextError, Extension};
 
 use std::sync::atomic::{AtomicU32, Ordering};
 
@@ -166,9 +166,10 @@ fn init() -> Extension {
         .finish()
 }
 
-pub fn increment(ctx: Context) {
-    let counter = ctx.global().state().get::<AtomicU32>();
+pub fn increment(ctx: Context) -> Result<(), ContextError> {
+    let counter = ctx.global().get::<AtomicU32>()?;
     counter.fetch_add(1, Ordering::SeqCst);
+    Ok(())
 }
 ```
 
@@ -177,13 +178,14 @@ pub fn increment(ctx: Context) {
 Command group state is only accessible from command handlers within the same group.
 
 ```rust,skt-group
-use arma_rs::{Context, Extension};
+use arma_rs::{Context, ContextState, ContextError, Extension};
 
 use std::sync::atomic::{AtomicU32, Ordering};
 
-pub fn increment(ctx: Context) {
-    let counter = ctx.group().unwrap().state().get::<AtomicU32>();
+pub fn increment(ctx: Context) -> Result<(), ContextError> {
+    let counter = ctx.group()?.get::<AtomicU32>()?;
     counter.fetch_add(1, Ordering::SeqCst);
+    Ok(())
 }
 
 pub fn group() -> arma_rs::Group {

--- a/README.md.skt.md
+++ b/README.md.skt.md
@@ -5,7 +5,7 @@ fn main() {{}}
 ```
 
 ```rust,skt-call-init
-use arma_rs::{{*, loadout::*}};
+use arma_rs::{{loadout::*}};
 fn main() {{
     let ext = init();
 }}
@@ -14,7 +14,6 @@ fn main() {{
 ```
 
 ```rust,skt-group
-use arma_rs::{{*, loadout::*}};
 fn main() {{
     let ext = arma_rs::Extension::build().group("test", group()).finish();
 }}

--- a/arma-rs-example/src/counter.rs
+++ b/arma-rs-example/src/counter.rs
@@ -1,17 +1,18 @@
 use std::sync::atomic::{AtomicU32, Ordering};
 
-use arma_rs::{Context, Group};
+use arma_rs::{Context, ContextError, ContextState, Group};
 
 pub struct Counter(pub AtomicU32);
 
-pub fn increment(ctx: Context) {
-    let counter = ctx.group().unwrap().state().get::<Counter>();
+pub fn increment(ctx: Context) -> Result<(), ContextError> {
+    let counter = ctx.group()?.get::<Counter>()?;
     counter.0.fetch_add(1, Ordering::SeqCst);
+    Ok(())
 }
 
-pub fn current(ctx: Context) -> u32 {
-    let counter = ctx.group().unwrap().state().get::<Counter>();
-    counter.0.load(Ordering::SeqCst)
+pub fn current(ctx: Context) -> Result<u32, ContextError> {
+    let counter = ctx.group()?.get::<Counter>()?;
+    Ok(counter.0.load(Ordering::SeqCst))
 }
 
 pub fn group() -> Group {

--- a/arma-rs/src/context/global.rs
+++ b/arma-rs/src/context/global.rs
@@ -25,7 +25,7 @@ impl ContextState for GlobalContext {
     where
         T: Send + Sync + 'static,
     {
-        self.state.try_get().ok_or(ContextError::NoGroupState)
+        self.state.try_get().ok_or(ContextError::NotInState)
     }
 
     fn set<T>(&self, value: T) -> bool

--- a/arma-rs/src/context/global.rs
+++ b/arma-rs/src/context/global.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use crate::State;
+use crate::{ContextError, ContextState, State};
 
 /// Contains information about the extension
 pub struct GlobalContext {
@@ -18,10 +18,20 @@ impl GlobalContext {
     pub fn version(&self) -> &str {
         &self.version
     }
+}
 
-    #[must_use]
-    /// Global state container
-    pub fn state(&self) -> &State {
-        &self.state
+impl ContextState for GlobalContext {
+    fn get<T>(&self) -> Result<&T, ContextError>
+    where
+        T: Send + Sync + 'static,
+    {
+        self.state.try_get().ok_or(ContextError::NoGroupState)
+    }
+
+    fn set<T>(&self, value: T) -> bool
+    where
+        T: Send + Sync + 'static,
+    {
+        self.state.set(value)
     }
 }

--- a/arma-rs/src/context/group.rs
+++ b/arma-rs/src/context/group.rs
@@ -18,7 +18,7 @@ impl ContextState for GroupContext {
     where
         T: Send + Sync + 'static,
     {
-        self.state.try_get().ok_or(ContextError::NoGroupState)
+        self.state.try_get().ok_or(ContextError::NotInState)
     }
 
     fn set<T>(&self, value: T) -> bool

--- a/arma-rs/src/context/group.rs
+++ b/arma-rs/src/context/group.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use crate::State;
+use crate::{ContextError, ContextState, State};
 
 /// Contains information about the current group
 pub struct GroupContext {
@@ -11,10 +11,20 @@ impl GroupContext {
     pub(crate) fn new(state: Arc<State>) -> Self {
         Self { state }
     }
+}
 
-    #[must_use]
-    /// Group state container
-    pub fn state(&self) -> &State {
-        &self.state
+impl ContextState for GroupContext {
+    fn get<T>(&self) -> Result<&T, ContextError>
+    where
+        T: Send + Sync + 'static,
+    {
+        self.state.try_get().ok_or(ContextError::NoGroupState)
+    }
+
+    fn set<T>(&self, value: T) -> bool
+    where
+        T: Send + Sync + 'static,
+    {
+        self.state.set(value)
     }
 }

--- a/arma-rs/src/context/mod.rs
+++ b/arma-rs/src/context/mod.rs
@@ -111,20 +111,17 @@ impl Context {
 
 /// Errors that can occur when trying to access context information
 pub enum ContextError {
-    /// The global state is not available
-    NoGlobalState,
-    /// The group state is not available
-    NoGroupState,
     /// The group context is not available
     NoGroupContext,
+    /// The type is not in the state
+    NotInState
 }
 
 impl ToString for ContextError {
     fn to_string(&self) -> String {
         match self {
-            Self::NoGlobalState => "No global state available".to_string(),
-            Self::NoGroupState => "No group state available".to_string(),
             Self::NoGroupContext => "No group context available".to_string(),
+            Self::NotInState => "Type not in state".to_string(),
         }
     }
 }

--- a/arma-rs/src/context/mod.rs
+++ b/arma-rs/src/context/mod.rs
@@ -64,7 +64,7 @@ impl Context {
     #[must_use]
     /// Context automatically provided by Arma. Supported since Arma version 2.11.
     pub const fn arma(&self) -> Option<&ArmaContext> {
-        self.arma.as_ref()1
+        self.arma.as_ref()
     }
 
     #[must_use]

--- a/arma-rs/src/context/mod.rs
+++ b/arma-rs/src/context/mod.rs
@@ -64,7 +64,7 @@ impl Context {
     #[must_use]
     /// Context automatically provided by Arma. Supported since Arma version 2.11.
     pub const fn arma(&self) -> Option<&ArmaContext> {
-        self.arma.as_ref()
+        self.arma.as_ref()1
     }
 
     #[must_use]
@@ -114,7 +114,7 @@ pub enum ContextError {
     /// The group context is not available
     NoGroupContext,
     /// The type is not in the state
-    NotInState
+    NotInState,
 }
 
 impl ToString for ContextError {

--- a/arma-rs/src/context/state.rs
+++ b/arma-rs/src/context/state.rs
@@ -1,0 +1,14 @@
+use crate::ContextError;
+
+/// A trait for accessing state values
+pub trait ContextState {
+    /// Get a reference to a state value
+    fn get<T>(&self) -> Result<&T, ContextError>
+    where
+        T: Send + Sync + 'static;
+
+    /// Set a state value
+    fn set<T>(&self, value: T) -> bool
+    where
+        T: Send + Sync + 'static;
+}

--- a/arma-rs/tests/main.rs
+++ b/arma-rs/tests/main.rs
@@ -1,4 +1,4 @@
-use arma_rs::{context, Context, Extension, Group};
+use arma_rs::{context, Context, ContextState, Extension, Group};
 
 include!(concat!(env!("OUT_DIR"), "/skeptic-tests.rs"));
 
@@ -288,9 +288,7 @@ fn state_build() {
 #[test]
 fn state_new() {
     let extension = Extension::build()
-        .command("new", |ctx: Context, new: String| {
-            ctx.global().state().set(new)
-        })
+        .command("new", |ctx: Context, new: String| ctx.global().set(new))
         .finish()
         .testing();
 
@@ -302,9 +300,7 @@ fn state_new() {
 #[test]
 fn state_freeze() {
     let extension = Extension::build()
-        .command("new", |ctx: Context, new: String| {
-            ctx.global().state().set(new)
-        })
+        .command("new", |ctx: Context, new: String| ctx.global().set(new))
         .freeze_state()
         .finish()
         .testing();
@@ -323,8 +319,8 @@ fn state_change() {
         .state(AtomicUsize::new(42))
         .command("set", |ctx: Context, new: usize| {
             ctx.global()
-                .state()
                 .get::<AtomicUsize>()
+                .expect("state not found")
                 .store(new, Ordering::Relaxed)
         })
         .finish()


### PR DESCRIPTION
I think this is a little bit cleaner, removes the `.state()` and only provides `get()` that returns a Result.

Thoughts on this?